### PR TITLE
upgrade 2022.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade app to version `2022.8.4`
+
 ## [0.3.0] - 2021-12-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ removal of the app. A pre delete hook will be executed that cleans the tunnel co
 |`initImage.pullPolicy`       | Init container image Pull Policy            | `IfNotPresent` |
 |`image.registry`             | Registry used for cloudflared               | `quay.io` |
 |`image.name`                 | Image name for cloudflared                  | `giantswarm/cloudflared` |
-|`image.tag`                  | Tag used for cloudflared image              | `2021.5.6` |
+|`image.tag`                  | Tag used for cloudflared image              | `2022.8.4-amd64` |
 |`image.pullPolicy`           | Pull policy for cloudflared image           | `IfNotPresent` |
 |`accountEmail`               | Account Email to use for the API (required) | `""` |
 |`accountId`                  | Account ID (see above, required)            | `""` |

--- a/helm/cloudflared/Chart.yaml
+++ b/helm/cloudflared/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 2021.11.0
-description: Create Argo Tunnels and configure ingress routes
+appVersion: 2022.8.4
+description: Create Cloudflared Tunnels and configure ingress routes
 keywords:
   - vpn
   - tunnel

--- a/helm/cloudflared/values.yaml
+++ b/helm/cloudflared/values.yaml
@@ -12,7 +12,7 @@ initImage:
 image:
   registry: quay.io
   name: giantswarm/cloudflared
-  tag: 2021.11.0
+  tag: 2022.8.4-amd64
   pullPolicy: IfNotPresent
 
 accountEmail: ""


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20258
Requires https://github.com/giantswarm/retagger/pull/731

This PR:

- Upgrade app to version 2022.8.4

### Testing

Description on how Cloudflared Tunnel can be tested.

- [x] fresh install works
  - [x] AWS
  - [x] Azure
  - [ ] KVM
- [x] upgrade from previous version works
  - [x] AWS
  - [x] Azure
  - [ ] KVM

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
