### PR TITLE
Add ability for specifying Deployment annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ability to specify annotations of the Deployment
+
 ## [0.4.0] - 2022-09-15
 
 ### Added

--- a/helm/cloudflared/templates/deployment.yaml
+++ b/helm/cloudflared/templates/deployment.yaml
@@ -4,6 +4,10 @@ kind: Deployment
 metadata:
   labels:
     {{- include "cloudflared.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   name: {{ template "cloudflared.fullname" . }}
 spec:
   replicas: {{ .Values.replicas }}

--- a/helm/cloudflared/values.schema.json
+++ b/helm/cloudflared/values.schema.json
@@ -8,6 +8,12 @@
         "accountId": {
             "type": "string"
         },
+        "annotations": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
         "apiKey": {
             "type": "string"
         },

--- a/helm/cloudflared/values.yaml
+++ b/helm/cloudflared/values.yaml
@@ -15,6 +15,8 @@ image:
   tag: 2022.8.4-amd64
   pullPolicy: IfNotPresent
 
+annotations: {}
+
 accountEmail: ""
 accountId: ""
 apiKey: ""


### PR DESCRIPTION
This PR adds the ability for specifying Deployment annotations. Towards #41 

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
