### PR TITLE
Do not install PSP if apiVersion not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ability to specify annotations of the Deployment
 
+### Changed
+
+- Do not install PodSecurityPolicy if api not available.
+
 ## [0.4.0] - 2022-09-15
 
 ### Added

--- a/helm/cloudflared/templates/psp.yaml
+++ b/helm/cloudflared/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -25,6 +26,7 @@ spec:
   hostIPC: false
   hostPID: false
   readOnlyRootFilesystem: true
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This PR changes the helm templates to not install PodSecurityPolicies if their apiVersion is not available.

Towards giantswarm/giantswarm#23400